### PR TITLE
Set chat EditText to use textCapSentences

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -174,7 +174,7 @@
                 android:background="@android:color/transparent"
                 android:hint="@string/send_message"
                 android:imeOptions="actionSend"
-                android:inputType="text|textAutoCorrect"
+                android:inputType="textCapSentences|textAutoCorrect"
                 android:maxLength="1500"
                 android:maxLines="1" />
 


### PR DESCRIPTION
This means words at the start of sentences will be capitalized. I would expect this to be the case for a chat app.

Fixes #316 