### PR TITLE
Guard against RealmConfig being null.

### DIFF
--- a/app/src/main/java/com/tokenbrowser/manager/store/ConversationStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/ConversationStore.java
@@ -170,13 +170,20 @@ public class ConversationStore {
     }
 
     public boolean areUnreadMessages() {
-        final Realm localRealmInstance = Realm.getDefaultInstance();
-        final Conversation result = localRealmInstance
+        final Realm realm;
+        try {
+            realm = Realm.getDefaultInstance();
+        } catch (final IllegalStateException ex) {
+            LogUtil.exception(getClass(), "RealmConfig unexpectedly null", ex);
+            return false;
+        }
+
+        final Conversation result = realm
                 .where(Conversation.class)
                 .greaterThan("numberOfUnread", 0)
                 .findFirst();
         final boolean areUnreadMessages = result != null;
-        localRealmInstance.close();
+        realm.close();
         return areUnreadMessages;
     }
 

--- a/app/src/main/java/com/tokenbrowser/manager/store/PendingMessageStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/PendingMessageStore.java
@@ -21,7 +21,9 @@ package com.tokenbrowser.manager.store;
 import com.tokenbrowser.model.local.PendingMessage;
 import com.tokenbrowser.model.local.SofaMessage;
 import com.tokenbrowser.model.local.User;
+import com.tokenbrowser.util.LogUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.realm.Realm;
@@ -43,7 +45,13 @@ public class PendingMessageStore {
 
     // Gets, and removes all messages. After calling this any pending messages will be removed
     public List<PendingMessage> fetchAllPendingMessages() {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm;
+        try {
+            realm = Realm.getDefaultInstance();
+        } catch (final IllegalStateException ex) {
+            LogUtil.exception(getClass(), "RealmConfig unexpectedly null", ex);
+            return new ArrayList<>(0);
+        }
         realm.beginTransaction();
         final RealmResults<PendingMessage> result = realm
                 .where(PendingMessage.class)


### PR DESCRIPTION
Partial Fix #319.
Really can't see how RealmConfig is null in these crashes so there is still an underlying issue.
This change catches the exception and logs it. There is loss of functionality if realm config is null in these situations but not enough to crash the app - needs more investigation.