### PR TITLE
Added the option to scan an payment address

### DIFF
--- a/app/src/main/java/com/tokenbrowser/presenter/ScannerPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/ScannerPresenter.java
@@ -64,8 +64,8 @@ public final class ScannerPresenter implements Presenter<ScannerActivity> {
 
     private void initShortLivingObjects() {
         initCloseButton();
-        initScanner();
         initQrCodeHandler();
+        initScanner();
     }
 
     private void initCloseButton() {
@@ -83,7 +83,7 @@ public final class ScannerPresenter implements Presenter<ScannerActivity> {
 
     private void initQrCodeHandler() {
         this.qrCodeHandler = new QrCodeHandler(this.activity);
-        this.qrCodeHandler.setOnQrCodeHandlerListener(() -> handleInvalidQrCode());
+        this.qrCodeHandler.setOnQrCodeHandlerListener(this::handleInvalidQrCode);
     }
 
     private void handleInvalidQrCode() {

--- a/app/src/main/java/com/tokenbrowser/util/QrCode.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCode.java
@@ -42,6 +42,10 @@ public class QrCode {
         this.url = url;
     }
 
+    public String getUrl() {
+        return this.url;
+    }
+
     public @QrCodeType.Type int getQrCodeType() {
         final String baseUrl = BaseApplication.get().getString(R.string.qr_code_base_url);
         if (this.url.startsWith(baseUrl + PAY_TYPE)) {
@@ -49,7 +53,9 @@ public class QrCode {
         } else if (this.url.startsWith(baseUrl + ADD_TYPE)) {
             return QrCodeType.ADD;
         } else if (this.url.startsWith(EXTERNAL_URL_PREFIX)) {
-            return QrCodeType.EXTERNAL;
+            return isPaymentAddressQrCode()
+                    ? QrCodeType.PAYMENT_ADDRESS
+                    : QrCodeType.PAY;
         } else {
             return QrCodeType.INVALID;
         }
@@ -158,5 +164,10 @@ public class QrCode {
     public static Single<Bitmap> generatePaymentAddressQrCode(final String paymentAddress) {
         final String url = String.format("ethereum:%s", paymentAddress);
         return ImageUtil.generateQrCode(url);
+    }
+
+    private boolean isPaymentAddressQrCode() {
+        final String[] splittedUrl = this.url.split("\\?");
+        return splittedUrl.length == 1;
     }
 }

--- a/app/src/main/java/com/tokenbrowser/util/QrCodeHandler.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCodeHandler.java
@@ -1,5 +1,8 @@
 package com.tokenbrowser.util;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
@@ -52,6 +55,8 @@ public class QrCodeHandler implements PaymentConfirmationDialog.OnPaymentConfirm
             handleAddQrCode(qrCode);
         } else if (qrCodeType == QrCodeType.PAY) {
             handlePaymentQrCode(qrCode);
+        } else if (qrCodeType == QrCodeType.PAYMENT_ADDRESS) {
+            handlePaymentAddressQrCode(qrCode);
         } else if (result.startsWith(WEB_SIGNIN)) {
             handleWebLogin(result);
         } else {
@@ -167,6 +172,21 @@ public class QrCodeHandler implements PaymentConfirmationDialog.OnPaymentConfirm
                 .getUserManager()
                 .getUserByUsername(username)
                 .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    private void handlePaymentAddressQrCode(final QrCode qrCode) {
+        if (this.activity == null) return;
+        final ClipboardManager clipboard = (ClipboardManager) this.activity.getSystemService(Context.CLIPBOARD_SERVICE);
+        final ClipData clip = ClipData.newPlainText(this.activity.getString(R.string.payment_address), qrCode.getUrl());
+        clipboard.setPrimaryClip(clip);
+
+        Toast.makeText(
+                this.activity,
+                this.activity.getString(R.string.copied_payment_address_to_clipboard, qrCode.getUrl()),
+                Toast.LENGTH_LONG
+        ).show();
+
+        this.activity.finish();
     }
 
     private void handleWebLogin(final String result) {

--- a/app/src/main/java/com/tokenbrowser/util/QrCodeType.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCodeType.java
@@ -20,10 +20,11 @@ package com.tokenbrowser.util;
 import android.support.annotation.IntDef;
 
 public class QrCodeType {
-    @IntDef({ADD, PAY, EXTERNAL, INVALID})
+    @IntDef({ADD, PAY, EXTERNAL, INVALID, PAYMENT_ADDRESS})
     public @interface Type {}
     public static final int ADD = 1;
     public static final int PAY = 2;
     public static final int EXTERNAL = 3;
     public static final int INVALID = 4;
+    public static final int PAYMENT_ADDRESS = 5;
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,4 +180,5 @@
     <string name="payment_address">Payment address</string>
     <string name="invalid_payment">Invalid payment</string>
     <string name="payment_address_with_value">Payment address: %1$s</string>
+    <string name="copied_payment_address_to_clipboard">Copied %1$s to clipboard</string>
 </resources>


### PR DESCRIPTION
Related to this PR: https://github.com/tokenbrowser/token-android-client/pull/315
Made it possible to scan a payment address. This was suppose to be merged into the `external-payment` branch, but forgot about it.