### PR TITLE
Returned wrong qr code type

### DIFF
--- a/app/src/main/java/com/tokenbrowser/util/QrCode.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCode.java
@@ -55,7 +55,7 @@ public class QrCode {
         } else if (this.url.startsWith(EXTERNAL_URL_PREFIX)) {
             return isPaymentAddressQrCode()
                     ? QrCodeType.PAYMENT_ADDRESS
-                    : QrCodeType.PAY;
+                    : QrCodeType.EXTERNAL_PAY;
         } else {
             return QrCodeType.INVALID;
         }
@@ -64,6 +64,7 @@ public class QrCode {
     public String getUsername() throws InvalidQrCode {
         try {
             final String username = Uri.parse(this.url).getLastPathSegment();
+            if (username == null) throw new InvalidQrCode();
             final String usernameWithoutPrefix = username.startsWith("@")
                     ? username.replaceFirst("@", "")
                     : null;
@@ -91,6 +92,7 @@ public class QrCode {
             final String baseUrl = String.format("%s%s/", BaseApplication.get().getString(R.string.qr_code_base_url), PAY_TYPE);
             this.url = this.url.replaceFirst(EXTERNAL_URL_PREFIX, baseUrl);
             final String address = Uri.parse(this.url).getLastPathSegment();
+            if (address == null) throw new InvalidQrCodePayment();
             return getPaymentWithParams()
                     .setAddress(address);
         } catch (UnsupportedOperationException e) {

--- a/app/src/main/java/com/tokenbrowser/util/QrCodeHandler.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCodeHandler.java
@@ -49,7 +49,7 @@ public class QrCodeHandler implements PaymentConfirmationDialog.OnPaymentConfirm
         final QrCode qrCode = new QrCode(result);
         final @QrCodeType.Type int qrCodeType = qrCode.getQrCodeType();
 
-        if (qrCodeType == QrCodeType.EXTERNAL) {
+        if (qrCodeType == QrCodeType.EXTERNAL_PAY) {
             handleExternalPayment(qrCode);
         } else if (qrCodeType == QrCodeType.ADD) {
             handleAddQrCode(qrCode);

--- a/app/src/main/java/com/tokenbrowser/util/QrCodeType.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCodeType.java
@@ -20,11 +20,11 @@ package com.tokenbrowser.util;
 import android.support.annotation.IntDef;
 
 public class QrCodeType {
-    @IntDef({ADD, PAY, EXTERNAL, INVALID, PAYMENT_ADDRESS})
+    @IntDef({ADD, PAY, EXTERNAL_PAY, INVALID, PAYMENT_ADDRESS})
     public @interface Type {}
     public static final int ADD = 1;
     public static final int PAY = 2;
-    public static final int EXTERNAL = 3;
+    public static final int EXTERNAL_PAY = 3;
     public static final int INVALID = 4;
     public static final int PAYMENT_ADDRESS = 5;
 }


### PR DESCRIPTION
When an external qr code was scanned, the wrong qr code type was returned.
Also guarding against empty query params
Related to this fabric crash https://fabric.io/bakken--bck2/android/apps/com.tokenbrowser/issues/590224eebe077a4dccff7b81?time=last-thirty-days