### PR TITLE
Check if reputation_score equals null

### DIFF
--- a/app/src/main/java/com/tokenbrowser/model/network/App.java
+++ b/app/src/main/java/com/tokenbrowser/model/network/App.java
@@ -32,6 +32,7 @@ public class App {
     }
 
     public Double getReputationScore() {
+        if (this.reputation_score == null) return 0.0;
         return reputation_score;
     }
 


### PR DESCRIPTION
App crashed because `reputation_score` was null
Related: https://fabric.io/bakken--bck2/android/apps/com.tokenbrowser/issues/590228c1be077a4dccffa3d7?time=last-thirty-days