### PR TITLE
Io cleanup

### DIFF
--- a/app/src/main/java/com/tokenbrowser/presenter/ImageCropPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/ImageCropPresenter.java
@@ -31,10 +31,8 @@ import com.tokenbrowser.view.activity.ImageCropActivity;
 
 import java.io.File;
 
-import rx.Single;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
-import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 
 public class ImageCropPresenter implements Presenter<ImageCropActivity> {
@@ -148,29 +146,16 @@ public class ImageCropPresenter implements Presenter<ImageCropActivity> {
     }
 
     private void createNewFileAndUploadAvatar(final Uri uri) {
+        final FileUtil fileUtil = new FileUtil();
         final Subscription sub =
-                saveFileFromUri(uri)
-                .flatMap(this::compressImage)
+                fileUtil.saveFileFromUri(this.activity, uri)
+                .flatMap(file -> fileUtil.compressImage(FileUtil.MAX_SIZE, file))
                 .subscribe(
                         this::uploadAvatar,
                         __ -> handleUploadError()
                 );
 
         this.subscriptions.add(sub);
-    }
-
-    private Single<File> saveFileFromUri(final Uri uri) {
-        return Single.fromCallable(() -> new FileUtil()
-                .saveFileFromUri(this.activity, uri))
-                .subscribeOn(Schedulers.io());
-    }
-
-    private Single<File> compressImage(final File file) {
-        return Single.fromCallable(() -> {
-            new FileUtil().compressImage(FileUtil.MAX_SIZE, file);
-            return file;
-        })
-        .subscribeOn(Schedulers.io());
     }
 
     private void uploadAvatar(final File file) {

--- a/app/src/main/java/com/tokenbrowser/presenter/chat/ChatPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/chat/ChatPresenter.java
@@ -846,16 +846,26 @@ public final class ChatPresenter implements
         }
 
         final File file = new File(filePath);
-        final FileUtil fileUtil = new FileUtil();
-        fileUtil.compressImage(FileUtil.MAX_SIZE, file);
-        sendMediaMessage(file.getAbsolutePath());
+        final Subscription sub =
+                new FileUtil().compressImage(FileUtil.MAX_SIZE, file)
+                .subscribe(
+                        compressedFile -> sendMediaMessage(compressedFile.getAbsolutePath()),
+                        this::handleError
+                );
+
+        this.subscriptions.add(sub);
     }
 
     private void handleCameraResult() throws FileNotFoundException {
         final File file = new File(this.activity.getFilesDir(), this.captureImageFilename);
-        final FileUtil fileUtil = new FileUtil();
-        fileUtil.compressImage(FileUtil.MAX_SIZE, file);
-        sendMediaMessage(file.getAbsolutePath());
+        final Subscription sub =
+                new FileUtil().compressImage(FileUtil.MAX_SIZE, file)
+                .subscribe(
+                        compressedFile -> sendMediaMessage(compressedFile.getAbsolutePath()),
+                        this::handleError
+                );
+
+        this.subscriptions.add(sub);
     }
 
     private void sendMediaMessage(final String filePath) {

--- a/app/src/main/java/com/tokenbrowser/util/FileUtil.java
+++ b/app/src/main/java/com/tokenbrowser/util/FileUtil.java
@@ -19,9 +19,11 @@ package com.tokenbrowser.util;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.webkit.MimeTypeMap;
 
@@ -112,5 +114,26 @@ public class FileUtil {
             return file;
         })
         .subscribeOn(Schedulers.io());
+    }
+
+    public String getDisplayNameFromUri(final Uri uri) {
+        final String [] projection = { MediaStore.Images.Media.DISPLAY_NAME };
+        final Cursor cursor =
+                BaseApplication.get()
+                .getContentResolver()
+                .query(
+                        uri,
+                        projection,
+                        null,
+                        null,
+                        null
+                );
+
+        if (cursor == null) return null;
+        final int column_index = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME);
+        cursor.moveToFirst();
+        final String displayName = cursor.getString(column_index);
+        cursor.close();
+        return displayName;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,4 +185,5 @@
     <string name="error__dapp_loading">Unable to launch web app</string>
     <string name="move_and_scale">Move and scale</string>
     <string name="crop_error">Unable to crop the image. Please try again</string>
+    <string name="confirm_image">Confirm image</string>
 </resources>


### PR DESCRIPTION
I discovered some IO work called on the main thread. These methods now returns a `Single` which runs on a worker thread.
In the second commit, I basically rewrote most of the ImageConfirmationPresenter. Before, it created a new file every time `initShortLivingObjects` was called. This was a bad solution. Now, we show the image and create a new file if the user approve.