### PR TITLE
Webview cleanup

### DIFF
--- a/app/src/main/java/com/tokenbrowser/presenter/webview/SOFAHost.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/webview/SOFAHost.java
@@ -1,0 +1,51 @@
+/*
+ * 	Copyright (c) 2017. Token Browser, Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.tokenbrowser.presenter.webview;
+
+
+import android.support.annotation.NonNull;
+import android.webkit.JavascriptInterface;
+
+/* package */ class SOFAHost {
+
+    private final SofaHostListener listener;
+
+    /* package */ SOFAHost(@NonNull final SofaHostListener listener) {
+        this.listener = listener;
+    }
+
+    @JavascriptInterface
+    public String getRcpUrl() {
+        return this.listener.getRcpUrl();
+    }
+
+    @JavascriptInterface
+    public String getAccounts() {
+        return this.listener.getAccounts();
+    }
+
+    @JavascriptInterface
+    public boolean approveTransaction(final String unsignedTransaction) {
+        return this.listener.approveTransaction(unsignedTransaction);
+    }
+
+    @JavascriptInterface
+    public void signTransaction(final String unsignedTransaction) {
+        this.listener.signTransaction(unsignedTransaction);
+    }
+}

--- a/app/src/main/java/com/tokenbrowser/presenter/webview/SofaHostListener.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/webview/SofaHostListener.java
@@ -1,0 +1,25 @@
+/*
+ * 	Copyright (c) 2017. Token Browser, Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.tokenbrowser.presenter.webview;
+
+/* package */ interface SofaHostListener {
+    String getRcpUrl();
+    String getAccounts();
+    boolean approveTransaction(String unsignedTransaction);
+    void signTransaction(String unsignedTransaction);
+}

--- a/app/src/main/java/com/tokenbrowser/presenter/webview/SofaHostWrapper.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/webview/SofaHostWrapper.java
@@ -1,0 +1,111 @@
+/*
+ * 	Copyright (c) 2017. Token Browser, Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.tokenbrowser.presenter.webview;
+
+
+import android.support.v7.app.AppCompatActivity;
+
+import com.tokenbrowser.R;
+import com.tokenbrowser.crypto.HDWallet;
+import com.tokenbrowser.model.local.UnsignedW3Transaction;
+import com.tokenbrowser.model.sofa.SofaAdapters;
+import com.tokenbrowser.util.LogUtil;
+import com.tokenbrowser.view.BaseApplication;
+import com.tokenbrowser.view.fragment.DialogFragment.PaymentConfirmationDialog;
+import com.tokenbrowser.view.fragment.DialogFragment.WebPaymentConfirmationListener;
+
+import java.io.IOException;
+
+/* package */ class SofaHostWrapper implements SofaHostListener {
+
+    private final AppCompatActivity activity;
+    private final SOFAHost sofaHost;
+    private final HDWallet wallet;
+    private PaymentConfirmationDialog paymentConfirmationDialog;
+
+    /* package */ SofaHostWrapper(final AppCompatActivity activity) {
+        this.activity = activity;
+        this.sofaHost = new SOFAHost(this);
+        this.wallet = BaseApplication
+                        .get()
+                        .getTokenManager()
+                        .getWallet()
+                        .toBlocking()
+                        .value();
+    }
+
+    /* package */ SOFAHost getSofaHost() {
+        return this.sofaHost;
+    }
+
+    public String getRcpUrl() {
+        return BaseApplication.get().getResources().getString(R.string.rcp_url);
+    }
+
+    public String getAccounts() {
+        return "[\"" + this.wallet.getPaymentAddress() + "\"]";
+    }
+
+    public boolean approveTransaction(final String unsignedTransaction) {
+        final UnsignedW3Transaction transaction;
+        try {
+            transaction = SofaAdapters.get().unsignedW3TransactionFrom(unsignedTransaction);
+        } catch (final IOException e) {
+            LogUtil.exception(getClass(), "Unable to parse unsigned transaction. ", e);
+            return false;
+        }
+
+        return transaction.getFrom().equals(this.wallet.getPaymentAddress());
+    }
+
+    public void signTransaction(final String unsignedTransaction) {
+        final UnsignedW3Transaction transaction;
+        try {
+            transaction = SofaAdapters.get().unsignedW3TransactionFrom(unsignedTransaction);
+        } catch (final IOException e) {
+            LogUtil.exception(getClass(), "Unable to parse unsigned transaction. ", e);
+            return;
+        }
+        if (this.activity == null) return;
+        this.paymentConfirmationDialog =
+                PaymentConfirmationDialog
+                        .newInstanceWebPayment(
+                                unsignedTransaction,
+                                transaction.getTo(),
+                                transaction.getValue(),
+                                null
+                        );
+        this.paymentConfirmationDialog.show(this.activity.getSupportFragmentManager(), PaymentConfirmationDialog.TAG);
+        this.paymentConfirmationDialog.setOnPaymentConfirmationListener(this.confirmationListener);
+    }
+
+    /* package */ void destroy() {
+        if (this.paymentConfirmationDialog != null) {
+            this.paymentConfirmationDialog.dismiss();
+            this.paymentConfirmationDialog = null;
+        }
+    }
+
+    private final WebPaymentConfirmationListener confirmationListener = new WebPaymentConfirmationListener() {
+        @Override
+        public void onWebPaymentApproved(final String unsignedTransaction) {
+            final String signedTransaction = wallet.signTransaction(unsignedTransaction);
+            // To Do -- pass the signed transaction back to webview
+        }
+    };
+}

--- a/app/src/main/java/com/tokenbrowser/presenter/webview/WebViewPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/webview/WebViewPresenter.java
@@ -21,6 +21,7 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.webkit.JavascriptInterface;
+import android.webkit.WebSettings;
 import android.widget.Toast;
 
 import com.tokenbrowser.R;
@@ -64,11 +65,18 @@ public class WebViewPresenter implements Presenter<WebViewActivity> {
         }
         this.webClient = new SofaWebViewClient(this.loadedListener);
         this.sofaInjector = new SofaInjector(this.loadedListener);
-        this.activity.getBinding().webview.getSettings().setJavaScriptEnabled(true);
-        this.activity.getBinding().webview.getSettings().setBuiltInZoomControls(true);
-        this.activity.getBinding().webview.getSettings().setDisplayZoomControls(false);
+        initSettings();
         this.activity.getBinding().webview.addJavascriptInterface(new SOFAHost(), "SOFAHost");
         this.activity.getBinding().webview.setWebViewClient(this.webClient);
+    }
+
+    private void initSettings() {
+        final WebSettings webSettings = this.activity.getBinding().webview.getSettings();
+        webSettings.setJavaScriptEnabled(true);
+        webSettings.setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+        webSettings.setBuiltInZoomControls(true);
+        webSettings.setDisplayZoomControls(false);
+        webSettings.setUseWideViewPort(false);
     }
 
     private void initView() {


### PR DESCRIPTION
Nothing really changed here. I just pulled the part into seperate classes.

There is a little bit "too much" abstraction going on here. `SOFAHost` is communicating with `SofaHostWrapper` via a `SofaHostListener`.

There is a reason for this -- `SOFAHost` will be injected into the webview and when it is, it is vulnerable to being attacked from javascript on that webpage. Therefore we want as little code as possible in the injected object.