### PR TITLE
fix signature length when either r or s do not fill 32 bytes

### DIFF
--- a/app/src/main/java/com/tokenbrowser/crypto/ECKey.java
+++ b/app/src/main/java/com/tokenbrowser/crypto/ECKey.java
@@ -667,8 +667,8 @@ public class ECKey implements Serializable {
                     ? (byte) (this.v - 27)
                     :this.v;
 
-            final String hexR = ByteUtil.toHexString(ByteUtil.bigIntegerToBytes(this.r));
-            final String hexS = ByteUtil.toHexString(ByteUtil.bigIntegerToBytes(this.s));
+            final String hexR = ByteUtil.toZeroPaddedHexString(ByteUtil.bigIntegerToBytes(this.r), 64);
+            final String hexS = ByteUtil.toZeroPaddedHexString(ByteUtil.bigIntegerToBytes(this.s), 64);
             final String hexV = ByteUtil.toHexString(new byte[]{fixedV});
 
             return TypeConverter.toJsonHex(hexR + hexS + hexV);

--- a/app/src/main/java/com/tokenbrowser/crypto/util/ByteUtil.java
+++ b/app/src/main/java/com/tokenbrowser/crypto/util/ByteUtil.java
@@ -194,6 +194,26 @@ public class ByteUtil {
     }
 
     /**
+     * Convert a byte-array into a hex String.<br>
+     * Will pad the result with 0 to the length
+     * desired.
+     *
+     * @param data - byte-array to convert to a hex-string
+     * @param size - size of result in bytes
+     * @return hex representation of the data, zero padded to desired size.<br>
+     */
+    public static String toZeroPaddedHexString(final byte[] data, final int size) {
+        final String hex = toHexString(data);
+        final StringBuffer sb = new StringBuffer("");
+        final int requiredPadding = size - hex.length();
+        while (sb.length() < requiredPadding) {
+            sb.append("0");
+        }
+        sb.append(hex);
+        return sb.toString();
+    }
+
+    /**
      * Calculate packet length
      *
      * @param msg byte[]

--- a/app/src/test/java/com/tokenbrowser/crypto/util/ByteUtilTest.java
+++ b/app/src/test/java/com/tokenbrowser/crypto/util/ByteUtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * 	Copyright (c) 2017. Token Browser, Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.tokenbrowser.crypto.util;
+
+
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class ByteUtilTest {
+
+    @Test
+    public void toZeroPaddedHexStringReturnsCorrectSize() {
+        final byte[] unpaddedInput = "Hello".getBytes();
+        final int expectedSize = 32;
+        final String result = ByteUtil.toZeroPaddedHexString(unpaddedInput, expectedSize);
+        assertThat(result.length(), is(expectedSize));
+
+    }
+
+    @Test
+    public void toZeroPaddedHexStringDoesNotShortenLongInput() {
+        final byte[] unpaddedInput = "Hello".getBytes();
+        final int shorterSize = unpaddedInput.length - 1;
+        final String result = ByteUtil.toZeroPaddedHexString(unpaddedInput, shorterSize);
+        assertThat(result.length(), not(shorterSize));
+    }
+
+    @Test
+    public void toZeroPaddedHexStringCorrectlyConvertsToHex() {
+        final byte[] unpaddedInput = "Hello".getBytes();
+        final int size = 32;
+        final String asHex = Hex.toHexString(unpaddedInput);
+
+        final String result = ByteUtil.toZeroPaddedHexString(unpaddedInput, size);
+
+        assertThat(result, containsString(asHex));
+    }
+
+    @Test
+    public void toZeroPaddedHexStringCorrectlyPads() {
+        final byte[] unpaddedInput = "Hello".getBytes();
+        final int size = 32;
+        final String asHex = Hex.toHexString(unpaddedInput);
+
+        final String result = ByteUtil.toZeroPaddedHexString(unpaddedInput, size);
+        final String paddedArea = result.substring(0, result.length() - asHex.length());
+        final String withoutZero = paddedArea.replace("0", "");
+
+        assertThat(withoutZero.length(), is(0));
+    }
+
+    @Test
+    public void toZeroPaddedGivesCorrectResult() {
+        final byte[] unpaddedInput = "Hello World".getBytes();
+        final int size = 64;
+        final String expectedOutput = "00000000000000000000000000000000000000000048656c6c6f20576f726c64";
+
+        final String result = ByteUtil.toZeroPaddedHexString(unpaddedInput, size);
+
+        assertThat(result, is(expectedOutput));
+    }
+}


### PR DESCRIPTION
if either r or s don't fill out 32 bytes the signature generated ends up too short and is invalid.