### PR TITLE
Ensure signout works

### DIFF
--- a/app/src/main/java/com/tokenbrowser/manager/BalanceManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/BalanceManager.java
@@ -26,6 +26,7 @@ import com.tokenbrowser.manager.network.CurrencyService;
 import com.tokenbrowser.manager.network.EthereumService;
 import com.tokenbrowser.model.network.Balance;
 import com.tokenbrowser.model.network.Currencies;
+import com.tokenbrowser.model.network.GcmDeregistration;
 import com.tokenbrowser.model.network.GcmRegistration;
 import com.tokenbrowser.model.network.MarketRates;
 import com.tokenbrowser.model.network.ServerTime;
@@ -39,8 +40,6 @@ import com.tokenbrowser.view.BaseApplication;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.List;
 
 import rx.Completable;
 import rx.Single;
@@ -205,12 +204,12 @@ public class BalanceManager {
 
     private Completable unregisterGcmWithTimestamp(final String token, final ServerTime serverTime) {
         if (serverTime == null) {
-            throw new IllegalStateException("Unable to fetch server time");
+            return Completable.error(new IllegalStateException("Unable to fetch server time"));
         }
 
         return EthereumService
                 .getApi()
-                .unregisterGcm(serverTime.get(), new GcmRegistration(token, wallet.getPaymentAddress()));
+                .unregisterGcm(serverTime.get(), new GcmDeregistration(token));
     }
 
     /* package */ Single<Payment> getTransactionStatus(final String transactionHash) {

--- a/app/src/main/java/com/tokenbrowser/manager/TokenManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/TokenManager.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
-import rx.Completable;
 import rx.Single;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
@@ -158,20 +157,18 @@ public class TokenManager {
                 .toSingle();
     }
 
-    public Completable clearUserData() {
-        return Completable.fromAction(() -> {
-            this.sofaMessageManager.clear();
-            this.userManager.clear();
-            this.balanceManager.clear();
-            this.transactionManager.clear();
-            this.wallet.clear();
-            this.areManagersInitialised = false;
-            closeDatabase();
-            SignalPreferences.clear();
-            SharedPrefsUtil.setSignedOut();
-            SharedPrefsUtil.clear();
-            setWallet(null);
-        });
+    public void clearUserData() {
+        this.sofaMessageManager.clear();
+        this.userManager.clear();
+        this.balanceManager.clear();
+        this.transactionManager.clear();
+        this.wallet.clear();
+        this.areManagersInitialised = false;
+        closeDatabase();
+        SignalPreferences.clear();
+        SharedPrefsUtil.setSignedOut();
+        SharedPrefsUtil.clear();
+        setWallet(null);
     }
 
     private void closeDatabase() {

--- a/app/src/main/java/com/tokenbrowser/manager/network/EthereumInterface.java
+++ b/app/src/main/java/com/tokenbrowser/manager/network/EthereumInterface.java
@@ -18,6 +18,7 @@
 package com.tokenbrowser.manager.network;
 
 import com.tokenbrowser.model.network.Balance;
+import com.tokenbrowser.model.network.GcmDeregistration;
 import com.tokenbrowser.model.network.GcmRegistration;
 import com.tokenbrowser.model.network.SentTransaction;
 import com.tokenbrowser.model.network.ServerTime;
@@ -58,5 +59,5 @@ public interface EthereumInterface {
     @POST("/v1/gcm/deregister")
     Completable unregisterGcm(
             @Query("timestamp") long timestamp,
-            @Body GcmRegistration gcmRegistration);
+            @Body GcmDeregistration gcmDeregistration);
 }

--- a/app/src/main/java/com/tokenbrowser/manager/network/interceptor/SigningInterceptor.java
+++ b/app/src/main/java/com/tokenbrowser/manager/network/interceptor/SigningInterceptor.java
@@ -90,6 +90,7 @@ public class SigningInterceptor implements Interceptor {
                     .get()
                     .getTokenManager()
                     .getWallet()
+                    .onErrorReturn(__ -> null)
                     .toBlocking()
                     .value();
     }

--- a/app/src/main/java/com/tokenbrowser/model/network/GcmDeregistration.java
+++ b/app/src/main/java/com/tokenbrowser/model/network/GcmDeregistration.java
@@ -1,0 +1,26 @@
+/*
+ * 	Copyright (c) 2017. Token Browser, Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.tokenbrowser.model.network;
+
+public class GcmDeregistration {
+    private String registration_id;
+
+    public GcmDeregistration(final String gcmRegistrationId) {
+        this.registration_id = gcmRegistrationId;
+    }
+}

--- a/app/src/main/java/com/tokenbrowser/presenter/SignOutPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/SignOutPresenter.java
@@ -51,9 +51,11 @@ public class SignOutPresenter implements Presenter<SignOutActivity> {
     }
 
     private Completable clearAndUnregister() {
-        return clearUserDataAndLogOut()
-                .andThen(unregisterChatGcm())
-                .andThen(unregisterEthGcm());
+        return
+                unregisterChatGcm()
+                .andThen(unregisterEthGcm())
+                .doOnError(__ -> clearUserDataAndLogOut())
+                .doOnCompleted(this::clearUserDataAndLogOut);
     }
 
     private Completable unregisterChatGcm() {
@@ -74,8 +76,8 @@ public class SignOutPresenter implements Presenter<SignOutActivity> {
                         .unregisterFromGcm(token));
     }
 
-    private Completable clearUserDataAndLogOut() {
-        return BaseApplication
+    private void clearUserDataAndLogOut() {
+        BaseApplication
                 .get()
                 .getTokenManager()
                 .clearUserData();


### PR DESCRIPTION
Block the deletion of local data until the web calls are done.
If the web calls fail we will still delete local data, the web will be in an invalid state but so be it.

Ensuring that when deregistering from ETH GCMs that we delete all addresses, just just the local one.

Tested and works, but might be some edge cases.