### PR TITLE
Fixes for surviving reviving a dead app

### DIFF
--- a/app/src/main/java/com/tokenbrowser/crypto/signal/store/SignalIdentityKeyStore.java
+++ b/app/src/main/java/com/tokenbrowser/crypto/signal/store/SignalIdentityKeyStore.java
@@ -19,6 +19,7 @@ package com.tokenbrowser.crypto.signal.store;
 
 import com.tokenbrowser.crypto.signal.SignalPreferences;
 import com.tokenbrowser.crypto.signal.model.SignalIdentity;
+import com.tokenbrowser.view.BaseApplication;
 
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
@@ -65,7 +66,7 @@ public class SignalIdentityKeyStore implements IdentityKeyStore {
     }
 
     private void writeObjectToDatabase(final RealmObject object) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         try {
             realm.beginTransaction();
             realm.copyToRealmOrUpdate(object);

--- a/app/src/main/java/com/tokenbrowser/manager/TokenManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/TokenManager.java
@@ -59,6 +59,8 @@ public class TokenManager {
         this.sofaMessageManager = new SofaMessageManager();
         this.transactionManager = new TransactionManager();
         this.walletSubject.onNext(null);
+
+        tryInit().subscribe();
     }
 
     public Single<TokenManager> init() {

--- a/app/src/main/java/com/tokenbrowser/manager/TokenManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/TokenManager.java
@@ -125,6 +125,20 @@ public class TokenManager {
         Realm.setDefaultConfiguration(this.realmConfig);
     }
 
+    public final Single<Realm> getRealm() {
+        return Single.fromCallable(() -> {
+            while (this.realmConfig == null) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return Realm.getDefaultInstance();
+        });
+
+    }
+
     public final SofaMessageManager getSofaMessageManager() {
         return this.sofaMessageManager;
     }

--- a/app/src/main/java/com/tokenbrowser/manager/UserManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/UserManager.java
@@ -303,17 +303,15 @@ public class UserManager {
     }
 
     public Single<Boolean> isUserAContact(final User user) {
-        return Single
-                .fromCallable(() -> contactStore.userIsAContact(user))
-                .subscribeOn(Schedulers.io());
+        return this.contactStore.userIsAContact(user);
     }
 
-    public void deleteContact(final User user) {
-        this.contactStore.delete(user);
+    public Completable deleteContact(final User user) {
+        return this.contactStore.delete(user);
     }
 
-    public void saveContact(final User user) {
-        this.contactStore.save(user);
+    public Completable saveContact(final User user) {
+        return this.contactStore.save(user);
     }
 
     public Single<Boolean> isUserBlocked(final String ownerAddress) {

--- a/app/src/main/java/com/tokenbrowser/manager/store/BlockedUserStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/BlockedUserStore.java
@@ -1,6 +1,7 @@
 package com.tokenbrowser.manager.store;
 
 import com.tokenbrowser.model.local.BlockedUser;
+import com.tokenbrowser.view.BaseApplication;
 
 import io.realm.Realm;
 import rx.Single;
@@ -13,7 +14,7 @@ public class BlockedUserStore {
     }
 
     private BlockedUser loadWhere(final String fieldName, final String value) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final BlockedUser user =
                 realm.where(BlockedUser.class)
                         .equalTo(fieldName, value)
@@ -24,7 +25,7 @@ public class BlockedUserStore {
     }
 
     public void save(final BlockedUser blockedUser) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         realm.insertOrUpdate(blockedUser);
         realm.commitTransaction();
@@ -32,7 +33,7 @@ public class BlockedUserStore {
     }
 
     public void delete(final String ownerAddress) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         realm
                 .where(BlockedUser.class)

--- a/app/src/main/java/com/tokenbrowser/manager/store/ContactStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/ContactStore.java
@@ -20,6 +20,7 @@ package com.tokenbrowser.manager.store;
 
 import com.tokenbrowser.model.local.Contact;
 import com.tokenbrowser.model.local.User;
+import com.tokenbrowser.view.BaseApplication;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ import rx.Single;
 public class ContactStore {
 
     public boolean userIsAContact(final User user) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final boolean result = realm
                 .where(Contact.class)
                 .equalTo("owner_address", user.getTokenId())
@@ -41,7 +42,7 @@ public class ContactStore {
     }
 
     public void save(final User user) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         final User storedUser = realm.copyToRealmOrUpdate(user);
         final Contact contact = new Contact(storedUser);
@@ -51,7 +52,7 @@ public class ContactStore {
     }
 
     public void delete(final User user) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         realm
                 .where(Contact.class)
@@ -63,7 +64,7 @@ public class ContactStore {
     }
 
     public Single<List<Contact>> loadAll() {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final RealmQuery<Contact> query = realm.where(Contact.class);
         final RealmResults<Contact> results = query.findAll();
         final List<Contact> retVal = realm.copyFromRealm(results.sort("user.name"));

--- a/app/src/main/java/com/tokenbrowser/manager/store/ContactStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/ContactStore.java
@@ -27,48 +27,65 @@ import java.util.List;
 import io.realm.Realm;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
+import rx.Completable;
 import rx.Single;
+import rx.schedulers.Schedulers;
 
 public class ContactStore {
 
-    public boolean userIsAContact(final User user) {
-        final Realm realm = BaseApplication.get().getRealm();
-        final boolean result = realm
-                .where(Contact.class)
-                .equalTo("owner_address", user.getTokenId())
-                .findFirst() != null;
-        realm.close();
-        return result;
+    public Single<Boolean> userIsAContact(final User user) {
+        return Single.fromCallable(() -> {
+            final Realm realm = BaseApplication.get().getRealm();
+            final boolean result = realm
+                    .where(Contact.class)
+                    .equalTo("owner_address", user.getTokenId())
+                    .findFirst() != null;
+            realm.close();
+            return result;
+        })
+        .subscribeOn(Schedulers.io());
+
     }
 
-    public void save(final User user) {
-        final Realm realm = BaseApplication.get().getRealm();
-        realm.beginTransaction();
-        final User storedUser = realm.copyToRealmOrUpdate(user);
-        final Contact contact = new Contact(storedUser);
-        realm.insert(contact);
-        realm.commitTransaction();
-        realm.close();
+    public Completable save(final User user) {
+        return Completable.fromAction(() -> {
+            final Realm realm = BaseApplication.get().getRealm();
+            realm.beginTransaction();
+            final User storedUser = realm.copyToRealmOrUpdate(user);
+            final Contact contact = new Contact(storedUser);
+            realm.insert(contact);
+            realm.commitTransaction();
+            realm.close();
+        })
+        .subscribeOn(Schedulers.io());
     }
 
-    public void delete(final User user) {
-        final Realm realm = BaseApplication.get().getRealm();
-        realm.beginTransaction();
-        realm
-                .where(Contact.class)
-                .equalTo("owner_address", user.getTokenId())
-                .findFirst()
-                .deleteFromRealm();
-        realm.commitTransaction();
-        realm.close();
+    public Completable delete(final User user) {
+        return Completable.fromAction(() -> {
+            final Realm realm = BaseApplication.get().getRealm();
+            realm.beginTransaction();
+            realm
+                    .where(Contact.class)
+                    .equalTo("owner_address", user.getTokenId())
+                    .findFirst()
+                    .deleteFromRealm();
+            realm.commitTransaction();
+            realm.close();
+        })
+        .subscribeOn(Schedulers.io());
+
     }
 
     public Single<List<Contact>> loadAll() {
-        final Realm realm = BaseApplication.get().getRealm();
-        final RealmQuery<Contact> query = realm.where(Contact.class);
-        final RealmResults<Contact> results = query.findAll();
-        final List<Contact> retVal = realm.copyFromRealm(results.sort("user.name"));
-        realm.close();
-        return Single.just(retVal);
+        return Single.fromCallable(() -> {
+            final Realm realm = BaseApplication.get().getRealm();
+            final RealmQuery<Contact> query = realm.where(Contact.class);
+            final RealmResults<Contact> results = query.findAll();
+            final List<Contact> retVal = realm.copyFromRealm(results.sort("user.name"));
+            realm.close();
+            return retVal;
+        })
+        .subscribeOn(Schedulers.io());
+
     }
 }

--- a/app/src/main/java/com/tokenbrowser/manager/store/ConversationStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/ConversationStore.java
@@ -21,9 +21,10 @@ package com.tokenbrowser.manager.store;
 import android.util.Pair;
 
 import com.tokenbrowser.model.local.Conversation;
-import com.tokenbrowser.model.sofa.SofaMessage;
 import com.tokenbrowser.model.local.User;
+import com.tokenbrowser.model.sofa.SofaMessage;
 import com.tokenbrowser.util.LogUtil;
+import com.tokenbrowser.view.BaseApplication;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -91,7 +92,7 @@ public class ConversationStore {
                 broadcastNewChatMessage(user.getTokenId(), timestamMessage);
             }
 
-            final Realm realm = Realm.getDefaultInstance();
+            final Realm realm = BaseApplication.get().getRealm();
             realm.beginTransaction();
             final SofaMessage storedMessage = realm.copyToRealmOrUpdate(message);
             conversationToStore.setLatestMessage(storedMessage);
@@ -136,7 +137,7 @@ public class ConversationStore {
                 return null;
             }
 
-            final Realm realm = Realm.getDefaultInstance();
+            final Realm realm = BaseApplication.get().getRealm();
             realm.beginTransaction();
             storedConversation.setNumberOfUnread(0);
             realm.insertOrUpdate(storedConversation);
@@ -153,7 +154,7 @@ public class ConversationStore {
     }
 
     public List<Conversation> loadAll() {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final RealmQuery<Conversation> query = realm.where(Conversation.class);
         final RealmResults<Conversation> results = query.findAllSorted("updatedTime", Sort.DESCENDING);
         final List<Conversation> retVal = realm.copyFromRealm(results);
@@ -171,7 +172,7 @@ public class ConversationStore {
     }
 
     private Conversation loadWhere(final String fieldName, final String value) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final Conversation result = realm
                 .where(Conversation.class)
                 .equalTo(fieldName, value)
@@ -183,7 +184,7 @@ public class ConversationStore {
 
     public void updateMessage(final User user, final SofaMessage message) {
         Single.fromCallable(() -> {
-            final Realm realm = Realm.getDefaultInstance();
+            final Realm realm = BaseApplication.get().getRealm();
             realm.beginTransaction();
             realm.insertOrUpdate(message);
             realm.commitTransaction();
@@ -199,14 +200,7 @@ public class ConversationStore {
     }
 
     public boolean areUnreadMessages() {
-        final Realm realm;
-        try {
-            realm = Realm.getDefaultInstance();
-        } catch (final IllegalStateException ex) {
-            LogUtil.exception(getClass(), "RealmConfig unexpectedly null", ex);
-            return false;
-        }
-
+        final Realm realm = BaseApplication.get().getRealm();
         final Conversation result = realm
                 .where(Conversation.class)
                 .greaterThan("numberOfUnread", 0)

--- a/app/src/main/java/com/tokenbrowser/manager/store/PendingMessageStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/PendingMessageStore.java
@@ -19,11 +19,10 @@ package com.tokenbrowser.manager.store;
 
 
 import com.tokenbrowser.model.local.PendingMessage;
-import com.tokenbrowser.model.sofa.SofaMessage;
 import com.tokenbrowser.model.local.User;
-import com.tokenbrowser.util.LogUtil;
+import com.tokenbrowser.model.sofa.SofaMessage;
+import com.tokenbrowser.view.BaseApplication;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import io.realm.Realm;
@@ -36,7 +35,7 @@ public class PendingMessageStore {
                 .setReceiver(receiver)
                 .setSofaMessage(message);
 
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         realm.insertOrUpdate(pendingMessage);
         realm.commitTransaction();
@@ -45,13 +44,7 @@ public class PendingMessageStore {
 
     // Gets, and removes all messages. After calling this any pending messages will be removed
     public List<PendingMessage> fetchAllPendingMessages() {
-        final Realm realm;
-        try {
-            realm = Realm.getDefaultInstance();
-        } catch (final IllegalStateException ex) {
-            LogUtil.exception(getClass(), "RealmConfig unexpectedly null", ex);
-            return new ArrayList<>(0);
-        }
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         final RealmResults<PendingMessage> result = realm
                 .where(PendingMessage.class)

--- a/app/src/main/java/com/tokenbrowser/manager/store/PendingTransactionStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/PendingTransactionStore.java
@@ -19,6 +19,7 @@ package com.tokenbrowser.manager.store;
 
 
 import com.tokenbrowser.model.local.PendingTransaction;
+import com.tokenbrowser.view.BaseApplication;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class PendingTransactionStore {
     }
 
     public void save(final PendingTransaction pendingTransaction) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         realm.insertOrUpdate(pendingTransaction);
         realm.commitTransaction();
@@ -57,7 +58,7 @@ public class PendingTransactionStore {
     }
 
     private PendingTransaction loadSingleWhere(final String fieldName, final String value) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final RealmQuery<PendingTransaction> query = realm
                 .where(PendingTransaction.class)
                 .equalTo(fieldName, value);
@@ -69,7 +70,7 @@ public class PendingTransactionStore {
     }
 
     private List<PendingTransaction> loadAll() {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final RealmQuery<PendingTransaction> query = realm
                 .where(PendingTransaction.class);
 

--- a/app/src/main/java/com/tokenbrowser/manager/store/UserStore.java
+++ b/app/src/main/java/com/tokenbrowser/manager/store/UserStore.java
@@ -19,6 +19,7 @@ package com.tokenbrowser.manager.store;
 
 
 import com.tokenbrowser.model.local.User;
+import com.tokenbrowser.view.BaseApplication;
 
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class UserStore {
     }
 
     public void save(final User user) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         realm.beginTransaction();
         realm.insertOrUpdate(user);
         realm.commitTransaction();
@@ -51,7 +52,7 @@ public class UserStore {
     }
 
     private User loadWhere(final String fieldName, final String value) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final User user =
                 realm.where(User.class)
                 .equalTo(fieldName, value)
@@ -63,7 +64,7 @@ public class UserStore {
     }
 
     private List<User> filter(final String fieldName, final String value) {
-        final Realm realm = Realm.getDefaultInstance();
+        final Realm realm = BaseApplication.get().getRealm();
         final RealmQuery<User> query = realm.where(User.class);
         query.contains(fieldName, value, Case.INSENSITIVE);
         final List<User> result = realm.copyFromRealm(query.findAll());

--- a/app/src/main/java/com/tokenbrowser/presenter/ViewAppPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/ViewAppPresenter.java
@@ -43,6 +43,7 @@ import com.tokenbrowser.view.activity.AmountActivity;
 import com.tokenbrowser.view.activity.ChatActivity;
 import com.tokenbrowser.view.activity.ViewAppActivity;
 
+import rx.Completable;
 import rx.Single;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
@@ -214,12 +215,13 @@ public class ViewAppPresenter implements Presenter<ViewAppActivity> {
 
         private void toggleFavorite(final boolean isCurrentlyFavorited) {
             if (isCurrentlyFavorited) {
-                removeFromFavorites();
+                removeFromFavorites()
+                    .subscribe(() -> updateFavoriteButtonState());
             } else {
-                addToFavorites();
-                SoundManager.getInstance().playSound(SoundManager.ADD_CONTACT);
+                addToFavorites()
+                    .doOnCompleted(() -> SoundManager.getInstance().playSound(SoundManager.ADD_CONTACT))
+                    .subscribe(() -> updateFavoriteButtonState());
             }
-            updateFavoriteButtonState();
         }
     };
 
@@ -232,16 +234,16 @@ public class ViewAppPresenter implements Presenter<ViewAppActivity> {
                 .observeOn(AndroidSchedulers.mainThread());
     }
 
-    private void removeFromFavorites() {
-        BaseApplication
+    private Completable removeFromFavorites() {
+        return BaseApplication
                 .get()
                 .getTokenManager()
                 .getUserManager()
                 .deleteContact(this.appAsUser);
     }
 
-    private void addToFavorites() {
-        BaseApplication
+    private Completable addToFavorites() {
+        return BaseApplication
                 .get()
                 .getTokenManager()
                 .getUserManager()

--- a/app/src/main/java/com/tokenbrowser/presenter/ViewUserPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/ViewUserPresenter.java
@@ -47,6 +47,7 @@ import com.tokenbrowser.view.activity.AmountActivity;
 import com.tokenbrowser.view.activity.ChatActivity;
 import com.tokenbrowser.view.activity.ViewUserActivity;
 
+import rx.Completable;
 import rx.Single;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
@@ -247,12 +248,13 @@ public final class ViewUserPresenter implements
 
         private void handleAddContact(final boolean isAContact) {
             if (isAContact) {
-                deleteContact(user);
+                deleteContact(user)
+                        .subscribe(() -> updateAddContactState());
             } else {
-                saveContact(user);
-                SoundManager.getInstance().playSound(SoundManager.ADD_CONTACT);
+                saveContact(user)
+                        .doOnCompleted(() -> SoundManager.getInstance().playSound(SoundManager.ADD_CONTACT))
+                        .subscribe(() -> updateAddContactState());
             }
-            updateAddContactState();
         }
     };
 
@@ -269,16 +271,16 @@ public final class ViewUserPresenter implements
         LogUtil.exception(getClass(), "Error while checking if user is a contact", throwable);
     }
 
-    private void deleteContact(final User user) {
-        BaseApplication
+    private Completable deleteContact(final User user) {
+        return BaseApplication
             .get()
             .getTokenManager()
             .getUserManager()
             .deleteContact(user);
     }
 
-    private void saveContact(final User user) {
-        BaseApplication
+    private Completable saveContact(final User user) {
+        return BaseApplication
             .get()
             .getTokenManager()
             .getUserManager()

--- a/app/src/main/java/com/tokenbrowser/view/BaseApplication.java
+++ b/app/src/main/java/com/tokenbrowser/view/BaseApplication.java
@@ -25,7 +25,9 @@ import android.support.multidex.MultiDexApplication;
 
 import com.tokenbrowser.manager.TokenManager;
 import com.tokenbrowser.service.NetworkChangeReceiver;
+import com.tokenbrowser.util.LogUtil;
 
+import io.realm.Realm;
 import rx.subjects.BehaviorSubject;
 
 public final class BaseApplication extends MultiDexApplication {
@@ -39,6 +41,13 @@ public final class BaseApplication extends MultiDexApplication {
 
     public final TokenManager getTokenManager() {
         return this.tokenManager;
+    }
+
+    public final Realm getRealm() {
+        if (Thread.currentThread().getId() == 1) {
+            LogUtil.e(getClass(), "DB call done on Main Thread. Move this to a background thread.");
+        }
+        return this.tokenManager.getRealm().toBlocking().value();
     }
 
     @Override


### PR DESCRIPTION
The app crashes when opening it after the OS has wiped its memory. This is because the `Application` (and `ApplicationContext`) are destroyed.

Most things (everything under `TokenManager`) are recreated when a new `Application` is constructed. Realm isn't initialised again though as that is triggered through `SplashPresenter` and the OS won't route you through the splash screen when reviving an app (it'll just load up the last view you were in).

To fix this, I ensure Realm is always initialised when a new `Application` is initialised. See the first commit for more info.

This leaves us in the awkward situation that calls to Realm may be done before Realm is even intialised. The second commit addresses this by blocking access to Realm until Realm is initialised. Blocking calls aren't pretty; this one is no different. I'm happy for feedback on improvements.