### PR TITLE
Set correct payment type in UI

### DIFF
--- a/app/src/main/java/com/tokenbrowser/presenter/chat/ChatPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/chat/ChatPresenter.java
@@ -369,7 +369,7 @@ public final class ChatPresenter implements Presenter<ChatActivity> {
         @Override
         public void onSingleClick(final View v) {
             final Intent intent = new Intent(activity, AmountActivity.class)
-                    .putExtra(AmountActivity.VIEW_TYPE, PaymentType.TYPE_REQUEST);
+                    .putExtra(AmountActivity.VIEW_TYPE, PaymentType.TYPE_SEND);
             activity.startActivityForResult(intent, PAY_RESULT_CODE);
         }
     };


### PR DESCRIPTION
Clicking "Pay" in Chat, was causing the UI to render as if it were "requesting" ETH.

It has been this way ever since it was added: https://github.com/tokenbrowser/token-android-client/commit/2837840#diff-b6e7a6a1ca0205a4e76c27f5fcc31c8cR265

Which seems odd. It looks like changing this will only have UI consequences, but it it hard to be certain.