### PR TITLE
Correctly render payment requests

### DIFF
--- a/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
@@ -593,7 +593,8 @@ public final class SofaMessageManager {
     private void saveIncomingMessageFromUserToDatabase(final User user, final DecryptedSignalMessage signalMessage) {
         final SofaMessage remoteMessage = new SofaMessage()
                 .makeNew(user, signalMessage.getBody())
-                .setAttachmentFilePath(signalMessage.getAttachmentFilePath());
+                .setAttachmentFilePath(signalMessage.getAttachmentFilePath())
+                .setSendState(SendState.STATE_RECEIVED);
         if (remoteMessage.getType() == SofaType.PAYMENT) {
             // Don't render incoming SOFA::Payments,
             // but ensure we have the sender cached.

--- a/app/src/main/java/com/tokenbrowser/view/adapter/MessageAdapter.java
+++ b/app/src/main/java/com/tokenbrowser/view/adapter/MessageAdapter.java
@@ -269,6 +269,7 @@ public final class MessageAdapter extends RecyclerView.Adapter<RecyclerView.View
                   .setAvatarUri(sofaMessage.getSender() != null ? sofaMessage.getSender().getAvatar() : null)
                   .setRemoteUser(remoteUser)
                   .setSendState(sofaMessage.getSendState())
+                  .__setIsFromRemote(isRemote)
                   .setOnApproveListener(this.handleOnPaymentRequestApproved)
                   .setOnRejectListener(this.handleOnPaymentRequestRejected)
                   .draw();

--- a/app/src/main/java/com/tokenbrowser/view/adapter/viewholder/PaymentRequestViewHolder.java
+++ b/app/src/main/java/com/tokenbrowser/view/adapter/viewholder/PaymentRequestViewHolder.java
@@ -104,7 +104,7 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
         renderBody();
         renderAvatar();
         renderStatus();
-        setSendState();
+        renderSendState();
     }
 
     private void renderAmounts() {
@@ -146,7 +146,7 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
     }
 
     private void renderAcceptStatusMessage() {
-        if (!isSendByRemote() || this.remotePaymentStatus == null || this.buttonWrapper == null) return;
+        if (!isSentByRemote() || this.remotePaymentStatus == null || this.buttonWrapper == null) return;
         this.buttonWrapper.setVisibility(View.GONE);
         this.remotePaymentStatus.setVisibility(View.VISIBLE);
         final String acceptMessage = BaseApplication.get().getString(R.string.you_accepted);
@@ -154,7 +154,7 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
     }
 
     private void renderRejectStatusMessage() {
-        if (!this.isSendByRemote() || this.remotePaymentStatus == null || this.buttonWrapper == null) return;
+        if (!this.isSentByRemote() || this.remotePaymentStatus == null || this.buttonWrapper == null) return;
         this.buttonWrapper.setVisibility(View.GONE);
         this.remotePaymentStatus.setVisibility(View.VISIBLE);
         final String rejectMessage = BaseApplication.get().getString(R.string.you_declined);
@@ -162,16 +162,15 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
     }
 
     private void renderPendingStatusMessage() {
-        if (!this.isSendByRemote() || this.buttonWrapper == null || this.remotePaymentStatus == null) return;
+        if (!this.isSentByRemote() || this.buttonWrapper == null || this.remotePaymentStatus == null) return;
         this.remotePaymentStatus.setVisibility(View.GONE);
         this.buttonWrapper.setVisibility(View.VISIBLE);
         this.declineButton.setOnClickListener(__ -> handleRejectedClicked());
         this.acceptButton.setOnClickListener(__ -> handleApprovedClicked());
     }
 
-    private boolean isSendByRemote() {
-        if (this.remoteUser == null || this.request == null) return false;
-        return this.request.getDestinationAddresss().equals(this.remoteUser.getPaymentAddress());
+    private boolean isSentByRemote() {
+        return this.request != null && this.sendState == SendState.STATE_RECEIVED;
     }
 
     private void handleApprovedClicked() {
@@ -184,7 +183,7 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
         this.onRejectListener.onItemClick(getAdapterPosition());
     }
 
-    private void setSendState() {
+    private void renderSendState() {
         if (this.sentStatus == null) return;
         final int visibility = this.sendState == SendState.STATE_FAILED || this.sendState == SendState.STATE_PENDING
                 ? View.VISIBLE

--- a/app/src/main/java/com/tokenbrowser/view/adapter/viewholder/PaymentRequestViewHolder.java
+++ b/app/src/main/java/com/tokenbrowser/view/adapter/viewholder/PaymentRequestViewHolder.java
@@ -170,7 +170,10 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
     }
 
     private boolean isSentByRemote() {
-        return this.request != null && this.sendState == SendState.STATE_RECEIVED;
+        // See comment for method: __setIsFromRemote
+        // return this.request != null && this.sendState == SendState.STATE_RECEIVED;
+        return this.__isRemote
+                || (this.request != null && this.sendState == SendState.STATE_RECEIVED);
     }
 
     private void handleApprovedClicked() {
@@ -189,5 +192,15 @@ public final class PaymentRequestViewHolder extends RecyclerView.ViewHolder {
                 ? View.VISIBLE
                 : View.GONE;
         this.sentStatus.setVisibility(visibility);
+    }
+
+    // Todo. Remove this code after September 1st 2017
+    // This is a hack to make payment requests retroactively render correctly.
+    // After enough time this hack will no longer be needed as incoming
+    // messages will be correctly labelled as having been "received"
+    private boolean __isRemote = false;
+    public PaymentRequestViewHolder __setIsFromRemote(final boolean isRemote) {
+        this.__isRemote = isRemote;
+        return this;
     }
 }


### PR DESCRIPTION
This is a result of using shaky logic to correctly render things.
When decided if something was sent by a remote user or not it is a bad idea to determine that by looking at the contents of the message -- instead, you should just actually find out who sent the message.

There was unfortunately a bug meaning that incoming messages were not being marked as incoming messages. I have fixed that. I had to add a workaround to ensure existing payment requests continued to be rendered correctly -- I have timestamped this fix so that it can be safely removed in the future.