### PR TITLE
HD wallet path derivation bug

### DIFF
--- a/app/src/main/java/com/tokenbrowser/crypto/HDWallet.java
+++ b/app/src/main/java/com/tokenbrowser/crypto/HDWallet.java
@@ -88,11 +88,11 @@ public class HDWallet {
     }
 
     private Wallet generateNewWallet() {
-        final Wallet wallet = new Wallet(NetworkParameters.fromID(NetworkParameters.ID_MAINNET));
-        final DeterministicSeed seed = wallet.getKeyChainSeed();
+        final Wallet walletForSeed = new Wallet(getNetworkParameters());
+        final DeterministicSeed seed = walletForSeed.getKeyChainSeed();
+        final Wallet wallet = new Wallet(getNetworkParameters(),  new EthereumKeyChainGroup(getNetworkParameters(), seed));
         final String masterSeed = seedToString(seed);
         saveMasterSeedToStorage(masterSeed);
-
         return wallet;
     }
 

--- a/app/src/main/java/com/tokenbrowser/manager/UserManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/UserManager.java
@@ -115,6 +115,8 @@ public class UserManager {
             registerNewUser();
         } else if (userNeedsToMigrate()) {
             migrateUser();
+        } else if (SharedPrefsUtil.shouldForceUserUpdate()) {
+            forceUpdateUser();
         } else {
             getExistingUser();
         }
@@ -158,6 +160,7 @@ public class UserManager {
                     this::updateCurrentUser,
                     this::handleUserRegistrationFailed
             );
+        SharedPrefsUtil.setForceUserUpdate(false);
     }
 
     private void handleUserRegistrationFailed(final Throwable throwable) {
@@ -186,9 +189,14 @@ public class UserManager {
     }
 
     private void migrateUser() {
+        forceUpdateUser();
+        SharedPrefsUtil.setWasMigrated(true);
+    }
+
+    private void forceUpdateUser() {
         final UserDetails ud = new UserDetails().setPaymentAddress(this.wallet.getPaymentAddress());
         updateUser(ud).subscribe();
-        SharedPrefsUtil.setWasMigrated(true);
+        SharedPrefsUtil.setForceUserUpdate(false);
     }
 
     public Single<User> updateUser(final UserDetails userDetails) {

--- a/app/src/main/java/com/tokenbrowser/util/SharedPrefsUtil.java
+++ b/app/src/main/java/com/tokenbrowser/util/SharedPrefsUtil.java
@@ -30,6 +30,7 @@ public class SharedPrefsUtil {
     private static final String HAS_LOADED_APP_FIRST_TIME = "hasLoadedAppFirstTime";
     private static final String LOCAL_CURRENCY_CODE = "localCurrencyCode";
     private static final String WAS_MIGRATED = "wasMigrated";
+    private static final String FORCE_USER_UPDATE = "forceUserUpdate";
 
     public static boolean hasOnboarded() {
         final SharedPreferences prefs = BaseApplication.get().getSharedPreferences(FileNames.USER_PREFS, Context.MODE_PRIVATE);
@@ -108,6 +109,18 @@ public class SharedPrefsUtil {
     public static boolean wasMigrated() {
         final SharedPreferences prefs = BaseApplication.get().getSharedPreferences(FileNames.USER_PREFS, Context.MODE_PRIVATE);
         return prefs.getBoolean(WAS_MIGRATED, false);
+    }
+
+    public static void setForceUserUpdate(final boolean forceUpdate) {
+        final SharedPreferences prefs = BaseApplication.get().getSharedPreferences(FileNames.USER_PREFS, Context.MODE_PRIVATE);
+        prefs.edit()
+                .putBoolean(FORCE_USER_UPDATE, forceUpdate)
+                .apply();
+    }
+
+    public static boolean shouldForceUserUpdate() {
+        final SharedPreferences prefs = BaseApplication.get().getSharedPreferences(FileNames.USER_PREFS, Context.MODE_PRIVATE);
+        return prefs.getBoolean(FORCE_USER_UPDATE, true);
     }
 
     // INFO: Does not clear all preferences.


### PR DESCRIPTION
Fixes #414 

When creating a new wallet the incorrect path was being used to derive payment address.
When opening the app a second time the correct path would be derived, but the old, incorrect address had already been registered on the backend.

This change fixes the original path derivation bug, and then triggers the client to reregister with the backend.