### PR TITLE
Refactor username search endpoints

### DIFF
--- a/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
@@ -513,7 +513,6 @@ public final class SofaMessageManager {
             .getTokenManager()
             .getUserManager()
             .getUserFromAddress(signalMessage.getSource())
-            .toSingle()
             .subscribe(
                     (user) -> this.saveIncomingMessageFromUserToDatabase(user, signalMessage),
                     ex -> LogUtil.e(getClass(), "Error getting user. " + ex)

--- a/app/src/main/java/com/tokenbrowser/manager/network/IdInterface.java
+++ b/app/src/main/java/com/tokenbrowser/manager/network/IdInterface.java
@@ -47,6 +47,7 @@ public interface IdInterface {
     Single<User> registerUser(@Body UserDetails details,
                               @Query("timestamp") long timestamp);
 
+    // Works for username or tokenid
     @GET("/v1/user/{id}")
     Single<User> getUser(@Path("id") String userId);
 

--- a/app/src/main/java/com/tokenbrowser/presenter/PaymentRequestConfirmPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/PaymentRequestConfirmPresenter.java
@@ -113,7 +113,6 @@ public class PaymentRequestConfirmPresenter implements Presenter<PaymentConfirma
                 .getTokenManager()
                 .getUserManager()
                 .getUserFromAddress(this.tokenId)
-                .toSingle()
                 .doOnSuccess(user -> this.user = user)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(

--- a/app/src/main/java/com/tokenbrowser/presenter/ViewAppPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/ViewAppPresenter.java
@@ -109,7 +109,7 @@ public class ViewAppPresenter implements Presenter<ViewAppActivity> {
                 .getUserFromAddress(this.appTokenId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .doOnCompleted(this::updateFavoriteButtonState)
+                .doOnSuccess(__ -> this.updateFavoriteButtonState())
                 .subscribe(
                         user -> this.appAsUser = user,
                         this::handleAppLoadingFailed

--- a/app/src/main/java/com/tokenbrowser/presenter/ViewUserPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/ViewUserPresenter.java
@@ -132,8 +132,7 @@ public final class ViewUserPresenter implements
                 .get()
                 .getTokenManager()
                 .getUserManager()
-                .getUserFromAddress(userAddress)
-                .toSingle();
+                .getUserFromAddress(userAddress);
     }
 
     private void fetchUserReputation() {

--- a/app/src/main/java/com/tokenbrowser/util/QrCodeHandler.java
+++ b/app/src/main/java/com/tokenbrowser/util/QrCodeHandler.java
@@ -181,7 +181,7 @@ public class QrCodeHandler implements PaymentConfirmationDialog.OnPaymentConfirm
                 .get()
                 .getTokenManager()
                 .getUserManager()
-                .getUserByUsername(username)
+                .getUserFromUsername(username)
                 .observeOn(AndroidSchedulers.mainThread());
     }
 


### PR DESCRIPTION
When clicking a username in chat it would do a query; which is incorrect. The username is known so it should just do a lookup for that exact username.

This triggered a big refactor because other places were incorrectly searching instead of just looking up the username correctly.