### PR TITLE
Hide group UI in release builds.

### DIFF
--- a/app/src/main/java/com/tokenbrowser/presenter/UserSearchPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/UserSearchPresenter.java
@@ -18,6 +18,7 @@
 package com.tokenbrowser.presenter;
 
 import android.content.Intent;
+import android.support.multidex.BuildConfig;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
@@ -92,7 +93,9 @@ public final class UserSearchPresenter
                 : this.activity.getString(R.string.new_chat);
         this.activity.getBinding().title.setText(title);
         this.activity.getBinding().closeButton.setOnClickListener(this.handleCloseClicked);
-        this.activity.getBinding().newGroup.setVisibility(isProfileType ? View.GONE : View.VISIBLE);
+        if (BuildConfig.DEBUG) {
+            this.activity.getBinding().newGroup.setVisibility(isProfileType ? View.GONE : View.VISIBLE);
+        }
     }
 
     private void initClickListeners() {


### PR DESCRIPTION
Until it is ready for release. @martintoften you need to be aware of this when adding UI components for group chat. We want to merge to `master` often, but, `master` has to be shippable at all times.