### PR TITLE
Allow for the creation of groups in Signal

### DIFF
--- a/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
@@ -23,6 +23,7 @@ import android.content.SharedPreferences;
 import android.support.annotation.Nullable;
 import android.util.Pair;
 
+import com.google.protobuf.ByteString;
 import com.tokenbrowser.BuildConfig;
 import com.tokenbrowser.R;
 import com.tokenbrowser.crypto.HDWallet;
@@ -36,6 +37,7 @@ import com.tokenbrowser.manager.model.SofaMessageTask;
 import com.tokenbrowser.manager.store.ConversationStore;
 import com.tokenbrowser.manager.store.PendingMessageStore;
 import com.tokenbrowser.model.local.Conversation;
+import com.tokenbrowser.model.local.Group;
 import com.tokenbrowser.model.local.PendingMessage;
 import com.tokenbrowser.model.local.SendState;
 import com.tokenbrowser.model.local.User;
@@ -71,7 +73,10 @@ import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentPoin
 import org.whispersystems.signalservice.api.messages.SignalServiceContent;
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
 import org.whispersystems.signalservice.api.messages.SignalServiceEnvelope;
+import org.whispersystems.signalservice.api.messages.SignalServiceGroup;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
+import org.whispersystems.signalservice.api.push.exceptions.EncapsulatedExceptions;
+import org.whispersystems.signalservice.internal.push.SignalServiceProtos;
 import org.whispersystems.signalservice.internal.push.SignalServiceUrl;
 
 import java.io.File;
@@ -142,6 +147,11 @@ public final class SofaMessageManager {
     public final void saveMessage(final User receiver, final SofaMessage message) {
         final SofaMessageTask messageTask = new SofaMessageTask(receiver, message, SofaMessageTask.SAVE_ONLY);
         this.chatMessageQueue.onNext(messageTask);
+    }
+
+    // Create a new group
+    public final Completable createGroup(final Group group) {
+        return sendMessageToGroup(group);
     }
 
     // Will store a tranasaction in the local database
@@ -354,6 +364,29 @@ public final class SofaMessageManager {
                 message.setSendState(SendState.STATE_FAILED);
                 updateExistingMessage(receiver, message);
             }
+        }
+    }
+
+    private Completable sendMessageToGroup(final Group group) {
+        try {
+            final SignalServiceProtos.GroupContext groupContext =
+                    SignalServiceProtos.GroupContext.newBuilder()
+                    .setId(ByteString.copyFromUtf8(group.getId()))
+                    .setType(SignalServiceProtos.GroupContext.Type.UPDATE)
+                    .addAllMembers(group.getMemberIds())
+                    .setName(group.getTitle())
+                    .build();
+
+            // Todo - Add avatar support
+            final SignalServiceGroup.Type type = SignalServiceGroup.Type.UPDATE;
+            final SignalServiceGroup signalGroup = new SignalServiceGroup(type, group.getIdBytes(), groupContext.getName(), groupContext.getMembersList(), null);
+            final SignalServiceDataMessage groupDataMessage = new SignalServiceDataMessage(System.currentTimeMillis(), signalGroup, null, null);
+
+            generateMessageSender().sendMessage(group.getMemberAddresses(), groupDataMessage);
+            return Completable.complete();
+        } catch (final IOException | EncapsulatedExceptions ex) {
+            LogUtil.error(getClass(), ex.toString());
+            return Completable.error(ex);
         }
     }
 

--- a/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
+++ b/app/src/main/java/com/tokenbrowser/manager/SofaMessageManager.java
@@ -368,26 +368,29 @@ public final class SofaMessageManager {
     }
 
     private Completable sendMessageToGroup(final Group group) {
-        try {
-            final SignalServiceProtos.GroupContext groupContext =
-                    SignalServiceProtos.GroupContext.newBuilder()
-                    .setId(ByteString.copyFromUtf8(group.getId()))
-                    .setType(SignalServiceProtos.GroupContext.Type.UPDATE)
-                    .addAllMembers(group.getMemberIds())
-                    .setName(group.getTitle())
-                    .build();
+        return Completable.fromCallable(() -> {
+                try {
+                    final SignalServiceProtos.GroupContext groupContext =
+                            SignalServiceProtos.GroupContext.newBuilder()
+                                    .setId(ByteString.copyFromUtf8(group.getId()))
+                                    .setType(SignalServiceProtos.GroupContext.Type.UPDATE)
+                                    .addAllMembers(group.getMemberIds())
+                                    .setName(group.getTitle())
+                                    .build();
 
-            // Todo - Add avatar support
-            final SignalServiceGroup.Type type = SignalServiceGroup.Type.UPDATE;
-            final SignalServiceGroup signalGroup = new SignalServiceGroup(type, group.getIdBytes(), groupContext.getName(), groupContext.getMembersList(), null);
-            final SignalServiceDataMessage groupDataMessage = new SignalServiceDataMessage(System.currentTimeMillis(), signalGroup, null, null);
+                    // Todo - Add avatar support
+                    final SignalServiceGroup.Type type = SignalServiceGroup.Type.UPDATE;
+                    final SignalServiceGroup signalGroup = new SignalServiceGroup(type, group.getIdBytes(), groupContext.getName(), groupContext.getMembersList(), null);
+                    final SignalServiceDataMessage groupDataMessage = new SignalServiceDataMessage(System.currentTimeMillis(), signalGroup, null, null);
 
-            generateMessageSender().sendMessage(group.getMemberAddresses(), groupDataMessage);
-            return Completable.complete();
-        } catch (final IOException | EncapsulatedExceptions ex) {
-            LogUtil.error(getClass(), ex.toString());
-            return Completable.error(ex);
-        }
+                    generateMessageSender().sendMessage(group.getMemberAddresses(), groupDataMessage);
+                    return Completable.complete();
+                } catch (final IOException | EncapsulatedExceptions ex) {
+                    return Completable.error(ex);
+                }
+            })
+            .subscribeOn(Schedulers.io())
+            .observeOn(Schedulers.io());
     }
 
     private void sendToSignal(final SofaMessageTask messageTask) throws UntrustedIdentityException, IOException {
@@ -513,12 +516,15 @@ public final class SofaMessageManager {
 
         if (content.getDataMessage().isPresent()) {
             final SignalServiceDataMessage dataMessage = content.getDataMessage().get();
-            final Optional<String> messageBody = dataMessage.getBody();
-            final Optional<List<SignalServiceAttachment>> attachments = dataMessage.getAttachments();
-            final DecryptedSignalMessage decryptedMessage = new DecryptedSignalMessage(messageSource, messageBody.get(), attachments);
+            if (dataMessage.isGroupUpdate()) { LogUtil.i(getClass(), "Current unhandled group message."); }
+            else {
+                final Optional<String> messageBody = dataMessage.getBody();
+                final Optional<List<SignalServiceAttachment>> attachments = dataMessage.getAttachments();
+                final DecryptedSignalMessage decryptedMessage = new DecryptedSignalMessage(messageSource, messageBody.get(), attachments);
 
-            saveIncomingMessageToDatabase(decryptedMessage);
-            return decryptedMessage;
+                saveIncomingMessageToDatabase(decryptedMessage);
+                return decryptedMessage;
+            }
         }
         return null;
     }

--- a/app/src/main/java/com/tokenbrowser/model/local/Group.java
+++ b/app/src/main/java/com/tokenbrowser/model/local/Group.java
@@ -19,13 +19,14 @@ package com.tokenbrowser.model.local;
 
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.spongycastle.util.encoders.Hex;
+import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import io.realm.RealmList;
@@ -51,9 +52,14 @@ public class Group extends RealmObject {
         return this.id;
     }
 
-    @Nullable
+    @NonNull
+    public byte[] getIdBytes() {
+        return Hex.decode(this.id);
+    }
+
+    @NonNull
     public String getTitle() {
-        return this.title;
+        return this.title == null ? "" : this.title;
     }
 
     @NonNull
@@ -77,5 +83,28 @@ public class Group extends RealmObject {
         } catch (final NoSuchAlgorithmException e) {
             throw new AssertionError(e);
         }
+    }
+
+    // Helper functions
+    public List<String> getMemberIds() {
+        if (this.members == null) {
+            return Collections.emptyList();
+        }
+        final List<String> ids = new LinkedList<>();
+        for (final User member : this.members) {
+            ids.add(member.getTokenId());
+        }
+        return ids;
+    }
+
+    public List<SignalServiceAddress> getMemberAddresses() {
+        if (this.members == null) {
+            return Collections.emptyList();
+        }
+        final List<SignalServiceAddress> ids = new LinkedList<>();
+        for (final User member : this.members) {
+            ids.add(new SignalServiceAddress(member.getTokenId()));
+        }
+        return ids;
     }
 }

--- a/app/src/main/java/com/tokenbrowser/presenter/GroupSetupPresenter.java
+++ b/app/src/main/java/com/tokenbrowser/presenter/GroupSetupPresenter.java
@@ -20,6 +20,7 @@ import com.tokenbrowser.BuildConfig;
 import com.tokenbrowser.R;
 import com.tokenbrowser.exception.PermissionException;
 import com.tokenbrowser.model.local.ActivityResultHolder;
+import com.tokenbrowser.model.local.Group;
 import com.tokenbrowser.model.local.PermissionResultHolder;
 import com.tokenbrowser.model.local.User;
 import com.tokenbrowser.util.FileUtil;
@@ -84,7 +85,19 @@ public class GroupSetupPresenter implements Presenter<GroupSetupActivity> {
         this.activity.getBinding().avatar.setOnClickListener(__ -> handleAvatarClicked());
     }
 
-    private void handleCreateClicked() {}
+    private void handleCreateClicked() {
+        final Group group = new Group(this.getGroupParticipantAdapter().getUsers());
+        final Subscription subscription = BaseApplication
+            .get()
+            .getTokenManager()
+            .getSofaMessageManager()
+            .createGroup(group)
+            .subscribe(
+                    () -> LogUtil.i(getClass(), "Group created."),
+                    ex -> LogUtil.e(getClass(), "Group creation failed: " + ex)
+            );
+        this.subscriptions.add(subscription);
+    }
 
     private void initRecyclerView() {
         final RecyclerView recyclerView = this.activity.getBinding().participants;
@@ -102,8 +115,8 @@ public class GroupSetupPresenter implements Presenter<GroupSetupActivity> {
     }
 
     private void initNumberOfParticipantsView() {
-        final int numberOfparticipants = getParticipantList().size();
-        final String participants = this.activity.getResources().getQuantityString(R.plurals.participants, numberOfparticipants, numberOfparticipants);
+        final int numberOfParticipants = getParticipantList().size();
+        final String participants = this.activity.getResources().getQuantityString(R.plurals.participants, numberOfParticipants, numberOfParticipants);
         this.activity.getBinding().numberOfParticipants.setText(participants);
     }
 
@@ -147,7 +160,7 @@ public class GroupSetupPresenter implements Presenter<GroupSetupActivity> {
                 .flatMap(this::fetchUser)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        user -> getGroupParticipantAdapter().addUser(user),
+                        this.getGroupParticipantAdapter()::addUser,
                         throwable -> LogUtil.exception(getClass(), "Error during fetching group participants", throwable)
                 );
 

--- a/app/src/main/java/com/tokenbrowser/view/adapter/GroupParticipantAdapter.java
+++ b/app/src/main/java/com/tokenbrowser/view/adapter/GroupParticipantAdapter.java
@@ -29,7 +29,7 @@ import com.tokenbrowser.view.adapter.viewholder.GroupParticipantViewHolder;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GroupParticipantAdapter extends RecyclerView.Adapter<GroupParticipantViewHolder> {
+public final class GroupParticipantAdapter extends RecyclerView.Adapter<GroupParticipantViewHolder> {
 
     private List<User> users;
 
@@ -41,6 +41,10 @@ public class GroupParticipantAdapter extends RecyclerView.Adapter<GroupParticipa
         this.users.add(user);
         notifyDataSetChanged();
         return this;
+    }
+
+    public List<User> getUsers() {
+        return this.users;
     }
 
     @Override

--- a/app/src/test/java/com/tokenbrowser/model/local/GroupTest.java
+++ b/app/src/test/java/com/tokenbrowser/model/local/GroupTest.java
@@ -1,0 +1,38 @@
+/*
+ * 	Copyright (c) 2017. Token Browser, Inc
+ *
+ * 	This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.tokenbrowser.model.local;
+
+
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class GroupTest {
+
+    @Test
+    public void idAsBytesIsAsGenerated() {
+        final Group group = new Group(Collections.emptyList());
+        final String id = group.getId();
+        final byte[] idBytes = group.getIdBytes();
+        assertThat(Hex.toHexString(idBytes), is(id));
+    }
+}


### PR DESCRIPTION
Very much WIP but not a problem to merge this.

Connects the UI to Signal. A group is created and send to the participants. A client being added to a group will currently ignore it.